### PR TITLE
Add support for external modules

### DIFF
--- a/cmd/bench/cmd/client.go
+++ b/cmd/bench/cmd/client.go
@@ -115,7 +115,7 @@ func runClient() error {
 			}
 			return err
 		}
-		rand.Read(txBytes) //nolint:gosec
+		rand.Read(txBytes) //nolint:gosec,staticcheck
 		logger.Log(logging.LevelDebug, fmt.Sprintf("Submitting transaction #%d", i))
 		if err := client.SubmitTransaction(txBytes); err != nil {
 			return err

--- a/cmd/externalmodule-test-client/client.go
+++ b/cmd/externalmodule-test-client/client.go
@@ -14,12 +14,12 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	beroConn, err := externalmodule.Connect(ctx, "ws://localhost:8080/bero")
+	conn1, err := externalmodule.Connect(ctx, "ws://localhost:8080/conn1")
 	if err != nil {
 		panic(err)
 	}
 
-	response, err := beroConn.Submit(ctx, stdtypes.ListOf(
+	response, err := conn1.Submit(ctx, stdtypes.ListOf(
 		stdevents.NewTestString("remote", "Ping"),
 		stdevents.NewRaw("remote", []byte{0, 1, 2, 3}),
 	))
@@ -27,13 +27,13 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Printf("Bero received %d events in response.\n", response.Len())
+	fmt.Printf("Conn1 received %d events in response.\n", response.Len())
 
-	cecoConn, err := externalmodule.Connect(ctx, "ws://localhost:8080/ceco")
+	conn2, err := externalmodule.Connect(ctx, "ws://localhost:8080/conn2")
 	if err != nil {
 		panic(err)
 	}
-	response, err = cecoConn.Submit(ctx, stdtypes.ListOf(
+	response, err = conn2.Submit(ctx, stdtypes.ListOf(
 		stdevents.NewTestString("remote", "Ping"),
 		stdevents.NewRaw("remote", []byte{0, 1, 2, 3}),
 	))
@@ -41,13 +41,13 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Printf("Ceco received %d events in response.\n", response.Len())
+	fmt.Printf("Conn2 received %d events in response.\n", response.Len())
 
-	err = beroConn.Close(ctx)
+	err = conn1.Close(ctx)
 	if err != nil {
 		panic(err)
 	}
-	err = cecoConn.Close(ctx)
+	err = conn2.Close(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/externalmodule-test-client/client.go
+++ b/cmd/externalmodule-test-client/client.go
@@ -3,10 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/filecoin-project/mir/pkg/externalmodule"
 	"github.com/filecoin-project/mir/stdevents"
 	"github.com/filecoin-project/mir/stdtypes"
-	"time"
 )
 
 func main() {

--- a/cmd/externalmodule-test-server/server.go
+++ b/cmd/externalmodule-test-server/server.go
@@ -22,8 +22,8 @@ func (e EmptyModule) ApplyEvents(events *stdtypes.EventList) (*stdtypes.EventLis
 
 func main() {
 	s := externalmodule.NewServer(
-		externalmodule.NewHandler("bero", EmptyModule{"bero"}),
-		externalmodule.NewHandler("ceco", EmptyModule{"ceco"}),
+		externalmodule.NewHandler("conn1", EmptyModule{"conn1"}),
+		externalmodule.NewHandler("conn2", EmptyModule{"conn2"}),
 	)
 
 	time.AfterFunc(10*time.Second, func() {

--- a/cmd/externalmodule-test-server/server.go
+++ b/cmd/externalmodule-test-server/server.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/filecoin-project/mir/pkg/externalmodule"
 	"github.com/filecoin-project/mir/stdevents"
 	"github.com/filecoin-project/mir/stdtypes"
-	"time"
 )
 
 type EmptyModule struct {

--- a/cmd/externalmodule-test/client.go
+++ b/cmd/externalmodule-test/client.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/filecoin-project/mir/pkg/externalmodule"
+	"github.com/filecoin-project/mir/stdevents"
+	"github.com/filecoin-project/mir/stdtypes"
+	"time"
+)
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	beroConn, err := externalmodule.Connect(ctx, "ws://localhost:8080/bero")
+	if err != nil {
+		panic(err)
+	}
+
+	response, err := beroConn.Submit(ctx, stdtypes.ListOf(
+		stdevents.NewTestString("remote", "Ping"),
+		stdevents.NewRaw("remote", []byte{0, 1, 2, 3}),
+	))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Bero received %d events in response.\n", response.Len())
+
+	cecoConn, err := externalmodule.Connect(ctx, "ws://localhost:8080/ceco")
+	if err != nil {
+		panic(err)
+	}
+	response, err = cecoConn.Submit(ctx, stdtypes.ListOf(
+		stdevents.NewTestString("remote", "Ping"),
+		stdevents.NewRaw("remote", []byte{0, 1, 2, 3}),
+	))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Ceco received %d events in response.\n", response.Len())
+
+	err = beroConn.Close(ctx)
+	if err != nil {
+		panic(err)
+	}
+	err = cecoConn.Close(ctx)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/cmd/externalmodule-test/server.go
+++ b/cmd/externalmodule-test/server.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"github.com/filecoin-project/mir/pkg/externalmodule"
+	"github.com/filecoin-project/mir/stdevents"
+	"github.com/filecoin-project/mir/stdtypes"
+	"time"
+)
+
+type EmptyModule struct {
+	prefix string
+}
+
+func (e EmptyModule) ImplementsModule() {}
+
+func (e EmptyModule) ApplyEvents(events *stdtypes.EventList) (*stdtypes.EventList, error) {
+	fmt.Printf("%s: Received %d event(s).\n", e.prefix, events.Len())
+	return stdtypes.ListOf(stdevents.NewTestString("anonymous-module", "Pong")), nil
+}
+
+func main() {
+	s := externalmodule.NewServer(
+		externalmodule.NewHandler("bero", EmptyModule{"bero"}),
+		externalmodule.NewHandler("ceco", EmptyModule{"ceco"}),
+	)
+
+	time.AfterFunc(10*time.Second, func() {
+		err := s.Stop()
+		if err != nil {
+			fmt.Printf("Error stopping server: %v\n", err)
+		}
+	})
+
+	err := s.Serve("0.0.0.0:8080")
+
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println("Server stopped cleanly.")
+	}
+}

--- a/cmd/mircat/debug.go
+++ b/cmd/mircat/debug.go
@@ -111,7 +111,7 @@ func debug(args *arguments) error {
 			for _, event := range entry.Events {
 
 				// Set the index of the event in the event log.
-				metadata.index = uint64(index)
+				metadata.index = uint64(index) //nolint:gosec
 
 				// If the event was selected by the user for inspection, pause before submitting it to the node.
 				// The processing continues after the user's interactive confirmation.
@@ -199,9 +199,6 @@ func debuggerNode(id stdtypes.NodeID, membership *trantorpbtypes.Membership) (*m
 		),
 		"iss":   protocol,
 		"timer": timer.New(),
-	}
-	if err != nil {
-		panic(fmt.Errorf("error initializing the Mir modules: %w", err))
 	}
 
 	node, err := mir.NewNode(id, mir.DefaultNodeConfig().WithLogger(logger), nodeModules, nil)

--- a/cmd/mircat/display.go
+++ b/cmd/mircat/display.go
@@ -69,7 +69,7 @@ func displayEvents(args *arguments) error { //nolint:gocognit
 			}
 			// getting events from entry
 			for _, event := range entry.Events {
-				metadata.index = uint64(index)
+				metadata.index = uint64(index) //nolint:gosec
 
 				_, validEvent := args.selectedEventNames[eventName(event)]
 				_, validDest := args.selectedEventDests[event.DestModule]

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require github.com/golang/mock v1.6.0
 
 require (
 	filippo.io/keygen v0.0.0-20230306160926-5201437acf8e
+	github.com/coder/websocket v1.8.12
 	github.com/dave/jennifer v1.5.1
 	github.com/drand/kyber v1.2.0
 	github.com/drand/kyber-bls12381 v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAu
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/cenkalti/backoff/v4 v4.0.0 h1:6VeaLF9aI+MAUQ95106HwWzYZgJJpZ4stumjj6RFYAU=
 github.com/cenkalti/backoff/v4 v4.0.0/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
+github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
+github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/dave/jennifer v1.5.1 h1:AI8gaM02nCYRw6/WTH0W+S6UNck9YqPZ05xoIxQtuoE=
 github.com/dave/jennifer v1.5.1/go.mod h1:AxTG893FiZKqxy3FP1kL80VMshSMuz2G+EgvszgGRnk=

--- a/pkg/availability/multisigcollector/multisigcollector.go
+++ b/pkg/availability/multisigcollector/multisigcollector.go
@@ -1,6 +1,7 @@
 package multisigcollector
 
 import (
+	"fmt"
 	"math"
 
 	"google.golang.org/protobuf/proto"
@@ -69,12 +70,17 @@ func NewReconfigurableModule(mc ModuleConfig, paramsTemplate ModuleParams, logge
 				submc := mc
 				submc.Self = mscID
 
+				// Check for integer overflow
+				if mscParams.MaxRequests > math.MaxInt {
+					return nil, fmt.Errorf("max requests too high for int type: %d", mscParams.MaxRequests)
+				}
+
 				// Fill in instance-specific parameters.
 				moduleParams := paramsTemplate
 				moduleParams.InstanceUID = []byte(mscID)
 				moduleParams.EpochNr = mscParams.Epoch
 				moduleParams.Membership = mscParams.Membership
-				moduleParams.MaxRequests = int(mscParams.MaxRequests)
+				moduleParams.MaxRequests = int(mscParams.MaxRequests) //nolint:gosec
 				// TODO: Use InstanceUIDs properly.
 				//       (E.g., concatenate this with the instantiating protocol's InstanceUID when introduced.)
 

--- a/pkg/checkpoint/chkpvalidator/permissivecv.go
+++ b/pkg/checkpoint/chkpvalidator/permissivecv.go
@@ -1,17 +1,17 @@
 package chkpvalidator
 
 import (
+	"math"
+
 	es "github.com/go-errors/errors"
-
-	t "github.com/filecoin-project/mir/stdtypes"
-
-	"github.com/filecoin-project/mir/pkg/logging"
 
 	"github.com/filecoin-project/mir/pkg/checkpoint"
 	"github.com/filecoin-project/mir/pkg/crypto"
+	"github.com/filecoin-project/mir/pkg/logging"
 	checkpointpbtypes "github.com/filecoin-project/mir/pkg/pb/checkpointpb/types"
 	trantorpbtypes "github.com/filecoin-project/mir/pkg/pb/trantorpb/types"
 	tt "github.com/filecoin-project/mir/pkg/trantor/types"
+	t "github.com/filecoin-project/mir/stdtypes"
 )
 
 type PermissiveCV struct {
@@ -50,13 +50,19 @@ func (pcv *PermissiveCV) Verify(chkp *checkpointpbtypes.StableCheckpoint, epochN
 		return es.Errorf("nodeID not in membership")
 	}
 
+	// Check if epoch is in integer bounds.
+	if sc.Epoch() > math.MaxInt || epochNr > math.MaxInt {
+		return es.Errorf("epoch number out of integer range")
+	}
+
 	// ATTENTION: We are using the membership contained in the checkpoint itself
 	// as the one to verify its certificate against.
 	// This is a vulnerability, since any the state of any node can be corrupted
 	// simply by receiving a maliciously crafted checkpoint.
 	// Thus, the permissive checker is a form of a stub and should not be used in production.
 	chkpMembership := sc.PreviousMembership()
-	chkpMembershipOffset := int(sc.Epoch()) - 1 - int(epochNr)
+	// Integer casting required here to prevent underflow.
+	chkpMembershipOffset := int(sc.Epoch()) - 1 - int(epochNr) //nolint:gosec
 
 	if chkpMembershipOffset > pcv.configOffset {
 		// cannot verify checkpoint signatures, too far ahead

--- a/pkg/deploytest/deployment.go
+++ b/pkg/deploytest/deployment.go
@@ -179,8 +179,8 @@ func (d *Deployment) Run(ctx context.Context) (nodeErrors []error, heapObjects i
 		<-ctx.Done()
 		runtime.GC()
 		runtime.ReadMemStats(&m2)
-		heapObjects = int64(m2.HeapObjects - m1.HeapObjects)
-		heapAlloc = int64(m2.HeapAlloc - m1.HeapAlloc)
+		heapObjects = int64(m2.HeapObjects - m1.HeapObjects) //nolint:gosec
+		heapAlloc = int64(m2.HeapAlloc - m1.HeapAlloc)       //nolint:gosec
 		cancel()
 	}()
 

--- a/pkg/deploytest/testreplica.go
+++ b/pkg/deploytest/testreplica.go
@@ -183,7 +183,7 @@ func (tr *TestReplica) submitFakeTransactions(ctx context.Context, node *mir.Nod
 				destModule,
 				[]*trantorpbtypes.Transaction{{
 					ClientId: tt.NewClientIDFromInt(0),
-					TxNo:     tt.TxNo(i),
+					TxNo:     tt.TxNo(i), //nolint:gosec
 					Data:     []byte(fmt.Sprintf("Transaction %d", i)),
 				}},
 			).Pb())

--- a/pkg/dsl/dslmodule.go
+++ b/pkg/dsl/dslmodule.go
@@ -162,16 +162,19 @@ func (h Handle) RecoverAndCleanupContext(id ContextID) any {
 // The ImplementsModule method only serves the purpose of indicating that this is a Module and must not be called.
 func (m *dslModuleImpl) ImplementsModule() {}
 
-// EmitEvent adds the event to the queue of output events
-// NB: This function works with the (legacy) protoc-generated types and is likely to be
-// removed in the future, with EmitMirEvent taking its place.
+// EmitEvent adds the event to the queue of output events.
 func EmitEvent(m Module, ev stdtypes.Event) {
 	m.DslHandle().impl.outputEvents.PushBack(ev)
 }
 
-// EmitMirEvent adds the event to the queue of output events
+// EmitEvents adds the events to the queue of output events.
+func EmitEvents(m Module, events *stdtypes.EventList) {
+	m.DslHandle().impl.outputEvents.PushBackList(events)
+}
+
+// EmitMirEvent adds the Mir-generated event to the queue of output events.
 // NB: this function works with the Mir-generated types.
-// For the (legacy) protoc-generated types, EmitEvent can be used.
+// For use with the general event type, see EmitEvent.
 func EmitMirEvent(m Module, ev *eventpbtypes.Event) {
 	m.DslHandle().impl.outputEvents.PushBack(ev.Pb())
 }

--- a/pkg/dsl/test/dslmodule_test.go
+++ b/pkg/dsl/test/dslmodule_test.go
@@ -278,7 +278,7 @@ func newContextTestingModule(mc *contextTestingModuleModuleConfig) dsl.Module {
 
 			// NB: avoid using primitive types as the context in the actual implementation, prefer named structs,
 			//     remember that the context type is used to match requests with responses.
-			cryptopbdsl.VerifySigs(m, mc.Crypto, sliceutil.Repeat(msg, int(u)), signatures, nodeIDs, &u)
+			cryptopbdsl.VerifySigs(m, mc.Crypto, sliceutil.Repeat(msg, int(u)), signatures, nodeIDs, &u) //nolint:gosec
 		}
 		return nil
 	})

--- a/pkg/externalmodule/connection.go
+++ b/pkg/externalmodule/connection.go
@@ -134,7 +134,7 @@ func receiveResponse(ctx context.Context, conn *websocket.Conn) (*stdtypes.Event
 	resultEvents := stdtypes.EmptyList()
 	for i := 0; i < command.NumEvents; i++ {
 
-		msgType, msgData, err := conn.Read(context.Background())
+		msgType, msgData, err := conn.Read(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("could not read response data: %w", err)
 		}

--- a/pkg/externalmodule/connection.go
+++ b/pkg/externalmodule/connection.go
@@ -1,0 +1,133 @@
+package externalmodule
+
+import (
+	"context"
+	"fmt"
+	"github.com/coder/websocket"
+	"github.com/filecoin-project/mir/stdevents"
+	"github.com/filecoin-project/mir/stdtypes"
+	"sync"
+)
+
+type Connection websocket.Conn
+
+func Connect(ctx context.Context, addr string) (*Connection, error) {
+
+	conn, _, err := websocket.Dial(ctx, addr, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return (*Connection)(conn), nil
+}
+
+func (c *Connection) Submit(ctx context.Context, events *stdtypes.EventList) (*stdtypes.EventList, error) {
+	conn := (*websocket.Conn)(c)
+	ctx, cancel := context.WithCancel(ctx)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	var sendErr error
+
+	// We need to run sendEvents concurrently with receiveResponse to avoid a deadlock.
+	// If we first tried to send all the events and only then started receiving the response, the sending could be
+	// blocked by the server side blocked by the processing blocked by the sending of response events blocked by the
+	// client not having started receiving them.
+	go func() {
+		sendErr = sendEvents(ctx, conn, events)
+		if sendErr != nil {
+			cancel() // If sending fails, receiving of the response also must be aborted.
+		}
+		wg.Done()
+	}()
+
+	response, err := receiveResponse(ctx, conn)
+
+	// When reaching this line, sending events must have finished, as receiveResponse would otherwise not have returned.
+	// Waiting on the wait group is not necessary in this sense.
+	// Nevertheless, we still need to synchronize access to sendErr
+	// (and it's good practice to collect spawned goroutines before returning).
+	wg.Wait()
+	if sendErr != nil {
+		return nil, sendErr
+	}
+
+	return response, err
+}
+
+func (c *Connection) Close(ctx context.Context) error {
+	conn := (*websocket.Conn)(c)
+	defer conn.CloseNow()
+
+	err := conn.Write(ctx, websocket.MessageBinary, controlMessageClose().Bytes())
+	if err != nil {
+		return err
+	}
+
+	return conn.Close(websocket.StatusNormalClosure, "")
+}
+
+func sendEvents(ctx context.Context, conn *websocket.Conn, events *stdtypes.EventList) error {
+	// Announce the number of events that will be sent.
+	err := conn.Write(ctx, websocket.MessageBinary, controlMessageEvents(events.Len()).Bytes())
+	if err != nil {
+		return err
+	}
+
+	// Send all the events, using one websocket message per event.
+	iter := events.Iterator()
+	for event := iter.Next(); event != nil; event = iter.Next() {
+
+		rawEvent, err := stdevents.WrapInRaw(event)
+		if err != nil {
+			return err
+		}
+
+		data, err := rawEvent.ToBytes()
+		if err != nil {
+			return err
+		}
+
+		err = conn.Write(ctx, websocket.MessageBinary, data)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func receiveResponse(ctx context.Context, conn *websocket.Conn) (*stdtypes.EventList, error) {
+	// Read the number of resulting events returned from the remote module.
+	msgType, msgData, err := conn.Read(ctx)
+	if msgType != websocket.MessageBinary {
+		return nil, fmt.Errorf("only binary message type is accepted for control messages")
+	}
+	command, err := controlMessageFromBytes(msgData)
+	if err != nil {
+		return nil, fmt.Errorf("could not load control message: %w", err)
+	}
+	if command.MsgType != MSG_EVENTS {
+		return nil, fmt.Errorf("expected MSG_EVENTS control message type but got %v", command.MsgType)
+	}
+
+	// Receive the resulting events.
+	resultEvents := stdtypes.EmptyList()
+	for i := 0; i < command.NumEvents; i++ {
+
+		msgType, msgData, err := conn.Read(context.Background())
+		if msgType != websocket.MessageBinary {
+			return nil, fmt.Errorf("only binary message type is accepted for events")
+		}
+
+		// We can afford using stdevents.Deserialize because sendEvents (used on the other side of the websocket)
+		// only ever sends serialized events of type stdevent.RawEvent
+		event, err := stdevents.Deserialize(msgData)
+		if err != nil {
+			return nil, fmt.Errorf("could not deserialize event: %w", err)
+		}
+
+		resultEvents.PushBack(event)
+	}
+
+	return resultEvents, nil
+}

--- a/pkg/externalmodule/controlmessage.go
+++ b/pkg/externalmodule/controlmessage.go
@@ -1,0 +1,40 @@
+package externalmodule
+
+import "encoding/json"
+
+type controlMessageType int
+
+const (
+	MSG_EVENTS = iota
+	MSG_CLOSE
+)
+
+type ControlMessage struct {
+	MsgType   controlMessageType
+	NumEvents int // Only used for EVENT_LIST type.
+}
+
+func (cm *ControlMessage) Bytes() []byte {
+	data, err := json.Marshal(cm)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func controlMessageFromBytes(data []byte) (*ControlMessage, error) {
+	var msg ControlMessage
+	err := json.Unmarshal(data, &msg)
+	if err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}
+
+func controlMessageEvents(numEvents int) *ControlMessage {
+	return &ControlMessage{MSG_EVENTS, numEvents}
+}
+
+func controlMessageClose() *ControlMessage {
+	return &ControlMessage{MSG_CLOSE, 0}
+}

--- a/pkg/externalmodule/controlmessage.go
+++ b/pkg/externalmodule/controlmessage.go
@@ -5,8 +5,8 @@ import "encoding/json"
 type controlMessageType int
 
 const (
-	MSG_EVENTS = iota
-	MSG_CLOSE
+	MsgEvents = iota
+	MsgClose
 )
 
 type ControlMessage struct {
@@ -32,9 +32,9 @@ func controlMessageFromBytes(data []byte) (*ControlMessage, error) {
 }
 
 func controlMessageEvents(numEvents int) *ControlMessage {
-	return &ControlMessage{MSG_EVENTS, numEvents}
+	return &ControlMessage{MsgEvents, numEvents}
 }
 
 func controlMessageClose() *ControlMessage {
-	return &ControlMessage{MSG_CLOSE, 0}
+	return &ControlMessage{MsgClose, 0}
 }

--- a/pkg/externalmodule/modulehandler.go
+++ b/pkg/externalmodule/modulehandler.go
@@ -1,0 +1,118 @@
+package externalmodule
+
+import (
+	"context"
+	"fmt"
+	"github.com/coder/websocket"
+	"github.com/filecoin-project/mir/pkg/modules"
+	"github.com/filecoin-project/mir/stdevents"
+	"github.com/filecoin-project/mir/stdtypes"
+	"net/http"
+	"sync/atomic"
+)
+
+const (
+	CONN_ACTIVE = iota
+	CONN_PENDING
+)
+
+type ModuleHandler struct {
+	path   string
+	module modules.PassiveModule
+
+	// Used to make sure there is only a single client talking to the server.
+	// This is needed to prevent concurrent access to the module.
+	connectionStatus int32
+}
+
+func NewHandler(path string, module modules.PassiveModule) *ModuleHandler {
+	return &ModuleHandler{
+		path:             path,
+		module:           module,
+		connectionStatus: CONN_PENDING,
+	}
+}
+
+func (mh *ModuleHandler) handleConnection(writer http.ResponseWriter, request *http.Request) {
+
+	if !atomic.CompareAndSwapInt32(&mh.connectionStatus, CONN_PENDING, CONN_ACTIVE) {
+		writer.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	conn, err := websocket.Accept(writer, request, nil)
+	if err != nil {
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	//TODO: Figure out a better way to deal with the context.
+	ctx := context.Background()
+
+	var msgType websocket.MessageType
+	var msgData []byte
+	for msgType, msgData, err = conn.Read(ctx); err == nil; msgType, msgData, err = conn.Read(ctx) {
+
+		if msgType != websocket.MessageBinary {
+			err = fmt.Errorf("only binary message type is accepted for control messages")
+			break
+		}
+
+		command, loadingErr := controlMessageFromBytes(msgData)
+		if loadingErr != nil {
+			err = fmt.Errorf("could not load control message: %w", loadingErr)
+			break
+		}
+
+		if command.MsgType == MSG_EVENTS {
+			err = mh.processEvents(ctx, conn, command.NumEvents)
+		} else if command.MsgType == MSG_CLOSE {
+			break
+		} else {
+			err = fmt.Errorf("unknown control msg type: %v", command.MsgType)
+			break
+		}
+
+	}
+	if err != nil {
+		fmt.Printf("Error processing incoming websocket message: %v\n", err)
+	}
+
+	err = conn.Close(websocket.StatusNormalClosure, "")
+	if err != nil {
+		_ = conn.CloseNow()
+	}
+}
+
+func (mh *ModuleHandler) processEvents(ctx context.Context, conn *websocket.Conn, numEvents int) error {
+	resultEvents := stdtypes.EmptyList()
+	for ; numEvents > 0; numEvents-- {
+		newEvents, err := mh.processNextEvent(ctx, conn)
+		if err != nil {
+			return err
+		}
+		resultEvents.PushBackList(newEvents)
+	}
+
+	return sendEvents(ctx, conn, resultEvents)
+}
+
+func (mh *ModuleHandler) processNextEvent(ctx context.Context, conn *websocket.Conn) (*stdtypes.EventList, error) {
+	msgType, msgData, err := conn.Read(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not read control message: %w", err)
+	}
+
+	if msgType != websocket.MessageBinary {
+		return nil, fmt.Errorf("only binary message type is accepted for events")
+	}
+
+	// We can afford using stdevents.Deserialize because sendEvents (used on the other side of the websocket)
+	// only ever sends serialized events of type stdevent.RawEvent
+	event, err := stdevents.Deserialize(msgData)
+	if err != nil {
+		return nil, fmt.Errorf("could not deserialize event: %w", err)
+	}
+
+	return mh.module.ApplyEvents(stdtypes.ListOf(event))
+}

--- a/pkg/externalmodule/proxymodule.go
+++ b/pkg/externalmodule/proxymodule.go
@@ -9,6 +9,10 @@ import (
 	"github.com/filecoin-project/mir/stdtypes"
 )
 
+// NewProxyModule returns a new module that serves as a local proxy to an external module hosted on a module server.
+// The addr parameter specifies the full URL (address and path) of the module at the server.
+// The connection between the proxy and the module server is established when the module receives stdevents.Init,
+// At which time the server must be running and accepting new connections.
 func NewProxyModule(moduleID stdtypes.ModuleID, addr string) modules.PassiveModule {
 	m := dsl.NewModule(moduleID)
 	var connection *Connection

--- a/pkg/externalmodule/proxymodule.go
+++ b/pkg/externalmodule/proxymodule.go
@@ -1,0 +1,52 @@
+package externalmodule
+
+import (
+	"context"
+	"github.com/filecoin-project/mir/pkg/dsl"
+	"github.com/filecoin-project/mir/pkg/modules"
+	"github.com/filecoin-project/mir/stdevents"
+	"github.com/filecoin-project/mir/stdtypes"
+)
+
+func NewProxyModule(moduleID stdtypes.ModuleID, addr string) modules.PassiveModule {
+	m := dsl.NewModule(moduleID)
+	var connection *Connection
+	ctx := context.Background()
+	// TODO: Using a local context here might make the whole Mir node stuck if the connection gets stuck.
+	//   There is no way to stop the module's operation from the outside - it can only stop by itself.
+	//   This is a more general problem of passive modules. There is no way to force them to stop processing when the
+	//   Mir node is shutting down. For most of the passive modules it is not an issue though, as they only locally
+	//   process events and are guaranteed to eventually finish. For the proxy module, this is only the case if it can
+	//   communicate with its corresponding server.
+
+	// Upon Init, connect to the remote module and relay the Init event to it.
+	dsl.UponEvent(m, func(ev *stdevents.Init) error {
+		var err error
+
+		// Create connection to module server.
+		connection, err = Connect(ctx, addr)
+		if err != nil {
+			return err
+		}
+
+		// Relay Init event to remote module.
+		eventsOut, err := connection.Submit(ctx, stdtypes.ListOf(ev))
+		if err != nil {
+			return err
+		}
+		dsl.EmitEvents(m, eventsOut)
+		return nil
+	})
+
+	// Simply relay all events (except for Init, which is handled separately) to the remote module.
+	dsl.UponOtherEvent(m, func(ev stdtypes.Event) error {
+		eventsOut, err := connection.Submit(ctx, stdtypes.ListOf(ev))
+		if err != nil {
+			return err
+		}
+		dsl.EmitEvents(m, eventsOut)
+		return nil
+	})
+
+	return m
+}

--- a/pkg/externalmodule/proxymodule.go
+++ b/pkg/externalmodule/proxymodule.go
@@ -2,6 +2,7 @@ package externalmodule
 
 import (
 	"context"
+
 	"github.com/filecoin-project/mir/pkg/dsl"
 	"github.com/filecoin-project/mir/pkg/modules"
 	"github.com/filecoin-project/mir/stdevents"

--- a/pkg/externalmodule/server.go
+++ b/pkg/externalmodule/server.go
@@ -3,6 +3,7 @@ package externalmodule
 import (
 	"net"
 	"net/http"
+	"time"
 )
 
 type Server struct {
@@ -27,7 +28,8 @@ func (ms *Server) Serve(addrPort string) error {
 	}
 
 	ms.httpServer = &http.Server{
-		Handler: ms,
+		ReadHeaderTimeout: 2 * time.Second,
+		Handler:           ms,
 	}
 
 	return ms.httpServer.Serve(l)

--- a/pkg/externalmodule/server.go
+++ b/pkg/externalmodule/server.go
@@ -6,11 +6,14 @@ import (
 	"time"
 )
 
+// Server implements a HTTP server containing remote modules.
 type Server struct {
 	serveMux   http.ServeMux
 	httpServer *http.Server
 }
 
+// NewServer returns a new Server containing the given moduleHandlers which define the modules operated by the server.
+// Each handler associates a module with a path under which the module will be accessible.
 func NewServer(moduleHandlers ...*ModuleHandler) *Server {
 	ms := Server{}
 
@@ -21,6 +24,9 @@ func NewServer(moduleHandlers ...*ModuleHandler) *Server {
 	return &ms
 }
 
+// Serve starts the module server, making it listen to new connections
+// at the given address and port (e.g., "0.0.0.0:8080").
+// Serve blocks until the Stop method is called. It is therefore expected to call Serve in a separate goroutine.
 func (ms *Server) Serve(addrPort string) error {
 	l, err := net.Listen("tcp", addrPort)
 	if err != nil {
@@ -35,10 +41,12 @@ func (ms *Server) Serve(addrPort string) error {
 	return ms.httpServer.Serve(l)
 }
 
+// Stop stops the server, making the call to the Serve method return.
 func (ms *Server) Stop() error {
 	return ms.httpServer.Close()
 }
 
+// ServeHTTP is a wrapper around the HTTP serveMux's method of the same name, so it can be used as a http.ServeMux.
 func (ms *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ms.serveMux.ServeHTTP(w, r)
 }

--- a/pkg/externalmodule/server.go
+++ b/pkg/externalmodule/server.go
@@ -1,0 +1,42 @@
+package externalmodule
+
+import (
+	"net"
+	"net/http"
+)
+
+type Server struct {
+	serveMux   http.ServeMux
+	httpServer *http.Server
+}
+
+func NewServer(moduleHandlers ...*ModuleHandler) *Server {
+	ms := Server{}
+
+	for _, mh := range moduleHandlers {
+		ms.serveMux.HandleFunc("/"+mh.path, mh.handleConnection)
+	}
+
+	return &ms
+}
+
+func (ms *Server) Serve(addrPort string) error {
+	l, err := net.Listen("tcp", addrPort)
+	if err != nil {
+		return err
+	}
+
+	ms.httpServer = &http.Server{
+		Handler: ms,
+	}
+
+	return ms.httpServer.Serve(l)
+}
+
+func (ms *Server) Stop() error {
+	return ms.httpServer.Close()
+}
+
+func (ms *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ms.serveMux.ServeHTTP(w, r)
+}

--- a/pkg/mempool/simplemempool/internal/parts/formbatchesint/formbatches.go
+++ b/pkg/mempool/simplemempool/internal/parts/formbatchesint/formbatches.go
@@ -19,6 +19,9 @@
 package formbatchesint
 
 import (
+	"fmt"
+	"math"
+
 	"github.com/filecoin-project/mir/pkg/clientprogress"
 	"github.com/filecoin-project/mir/pkg/dsl"
 	"github.com/filecoin-project/mir/pkg/logging"
@@ -156,7 +159,7 @@ func IncludeBatchCreation( // nolint:gocognit
 			cutBatch(origin)
 		} else {
 			reqID := storePendingRequest(origin)
-			stddsl.TimerDelay(m, mc.Timer, params.BatchTimeout, mppbevents.BatchTimeout(mc.Self, uint64(reqID)).Pb())
+			stddsl.TimerDelay(m, mc.Timer, params.BatchTimeout, mppbevents.BatchTimeout(mc.Self, uint64(reqID)).Pb()) //nolint:gosec
 		}
 	}
 
@@ -266,6 +269,9 @@ func IncludeBatchCreation( // nolint:gocognit
 
 	mppbdsl.UponBatchTimeout(m, func(batchReqID uint64) error {
 
+		if batchReqID > math.MaxInt {
+			return fmt.Errorf("batch request ID too big for an integer: %d", batchReqID)
+		}
 		reqID := int(batchReqID)
 
 		// Load the request origin.

--- a/pkg/net/grpc/remoteconnection.go
+++ b/pkg/net/grpc/remoteconnection.go
@@ -76,7 +76,7 @@ func (conn *remoteConnection) Send(msg *GrpcMessage) error {
 	case conn.msgBuffer <- msg:
 		return nil
 	default:
-		return es.Errorf("send buffer full (" + conn.addr + ")")
+		return es.Errorf("send buffer full (%s)", conn.addr)
 	}
 }
 

--- a/pkg/orderers/common/segment.go
+++ b/pkg/orderers/common/segment.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"math"
+
 	es "github.com/go-errors/errors"
 
 	"github.com/filecoin-project/mir/pkg/orderers/types"
@@ -44,7 +46,10 @@ func (seg *Segment) NodeIDs() []t.NodeID {
 }
 
 func (seg *Segment) PrimaryNode(view types.ViewNr) t.NodeID {
-	return seg.NodeIDs()[(seg.LeaderIndex()+int(view))%len(seg.NodeIDs())]
+	if view > math.MaxInt {
+		panic("view number out of integer range")
+	}
+	return seg.NodeIDs()[(seg.LeaderIndex()+int(view))%len(seg.NodeIDs())] //nolint:gosec
 }
 
 func (seg *Segment) LeaderIndex() int {

--- a/pkg/orderers/internal/common/common.go
+++ b/pkg/orderers/internal/common/common.go
@@ -97,8 +97,8 @@ type PbftProposalState struct {
 // ============================================================
 
 // NumCommitted returns the number of slots that are already committed in the given view.
-func (state *State) NumCommitted(view ot.ViewNr) int {
-	numCommitted := 0
+func (state *State) NumCommitted(view ot.ViewNr) uint64 {
+	numCommitted := uint64(0)
 	for _, slot := range state.Slots[view] {
 		if slot.Committed {
 			numCommitted++
@@ -151,7 +151,7 @@ func (state *State) InitView(
 		pbftpbevents.ViewChangeSNTimeout(
 			moduleConfig.Self,
 			view,
-			uint64(state.NumCommitted(view))).Pb(),
+			state.NumCommitted(view)).Pb(), //nolint:gosec
 	)
 	stddsl.TimerDelay(
 		m,
@@ -168,7 +168,7 @@ func (state *State) InitView(
 // AllCommitted returns true if all slots of this pbftInstance in the current view are in the committed state
 // (i.e., have the committed flag set).
 func (state *State) AllCommitted() bool {
-	return state.NumCommitted(state.View) == len(state.Slots[state.View])
+	return state.NumCommitted(state.View) == uint64(len(state.Slots[state.View]))
 }
 
 func (state *State) LookUpPreprepare(sn tt.SeqNr, digest []byte) *pbftpbtypes.Preprepare {

--- a/pkg/trantor/testing/smr_test.go
+++ b/pkg/trantor/testing/smr_test.go
@@ -198,7 +198,7 @@ func testIntegrationWithISS(tt *testing.T) {
 					require.Error(tb, conf.ErrorExpected)
 					for replica := range conf.NodeIDsWeight {
 						app := deployment.TestConfig.FakeApps[replica]
-						require.Equal(tb, 0, int(app.TransactionsProcessed))
+						require.Equal(tb, 0, int(app.TransactionsProcessed)) //nolint:gosec
 					}
 				},
 			}},
@@ -218,7 +218,7 @@ func testIntegrationWithISS(tt *testing.T) {
 					require.Error(tb, conf.ErrorExpected)
 					for replica := range conf.NodeIDsWeight {
 						app := deployment.TestConfig.FakeApps[replica]
-						require.Equal(tb, conf.NumNetTXs+conf.NumFakeTXs, int(app.TransactionsProcessed))
+						require.Equal(tb, conf.NumNetTXs+conf.NumFakeTXs, int(app.TransactionsProcessed)) //nolint:gosec
 					}
 				},
 			}},
@@ -379,7 +379,7 @@ func runIntegrationWithISSConfig(tb testing.TB, conf *TestConfig) (heapObjects i
 	// Check if all transactions were delivered.
 	for _, replica := range deployment.TestReplicas {
 		app := deployment.TestConfig.FakeApps[replica.ID]
-		assert.Equal(tb, conf.NumNetTXs+conf.NumFakeTXs, int(app.TransactionsProcessed))
+		assert.Equal(tb, conf.NumNetTXs+conf.NumFakeTXs, int(app.TransactionsProcessed)) //nolint:gosec
 	}
 
 	// If the test failed, keep the generated data.

--- a/stdmodules/factory/factory_test.go
+++ b/stdmodules/factory/factory_test.go
@@ -102,7 +102,7 @@ func TestFactoryModule(t *testing.T) {
 		},
 
 		"02 Instantiate many": func(t *testing.T) {
-			for i := 1; i <= 5; i++ {
+			for i := uint64(1); i <= 5; i++ {
 				evOut, err := echoFactory.ApplyEvents(stdtypes.ListOf(stdevents.NewNewSubmodule(
 					echoFactoryID,
 					echoFactoryID.Then(stdtypes.ModuleID(fmt.Sprintf("inst%d", i))),


### PR DESCRIPTION
Modules can now be run remotely, outside the Mir node,
in a dedicated module server.
The Mir node can use a proxy module that connects to this server
over a websocket interface and relays all the incoming events
to the remote server. The server applies the events to its local module
(which implements the actual module logic) and sends back the results.
Those resulting events are then emitted by the proxy module
(which lives in the Mir node).